### PR TITLE
packArguments broken

### DIFF
--- a/tests/jdom/command.spec.ts
+++ b/tests/jdom/command.spec.ts
@@ -17,6 +17,5 @@ describe('packArguments', () => {
     it("c32", () => testOne(ProtoTestCmd.CU32, [42]));
     it("cString", () => testOne(ProtoTestCmd.CString, ["hi"]));
     it("cI8U8U16I32", () => testOne(ProtoTestCmd.CI8U8U16I32, [-1, 2, 3, 4]));
-    // failing test
-    //it("cU8String", () => testOne(ProtoTestCmd.CU8String, [42, "hi"]));
+    it("cU8String", () => testOne(ProtoTestCmd.CU8String, [42, "hi"]));
 })


### PR DESCRIPTION
Added a test that fails with packArguments. Run to repro:
```
yarn watch
yarn test
```