### PR TITLE
Fix timestamp parsing in traces where there are decimals

### DIFF
--- a/src/jdom/logparser.ts
+++ b/src/jdom/logparser.ts
@@ -10,7 +10,7 @@ export function parseTrace(contents: string): Trace {
     const packets: Packet[] = []
     contents?.split(/\r?\n/).forEach(ln => {
         // parse data
-        const m = /(\d+)\s+([a-f0-9]{12,})/i.exec(ln)
+        const m = /^(\d+.?\d*)\s+([a-f0-9]{12,})/i.exec(ln)
         if (!m) {
             // probably junk data
             if (packets.length == 0) description.push(ln)


### PR DESCRIPTION
Because the regex wasn't anchored, when it encountered a decimal it would start parsing after the decimal, treating the fractional part as the integer part, which leads to ridiculously large numbers. This fixes that ... and also explains why devices weren't showing up, because it stops after the first packet 🤪.