### PR TITLE
JDOM Test Utilities

### DIFF
--- a/tests/jdom/button.spec.ts
+++ b/tests/jdom/button.spec.ts
@@ -3,7 +3,7 @@
 
 import { suite, test } from "mocha"
 import { ButtonEvent } from "../../src/jdom/constants"
-import { withBus, JDBusTestUtil } from "./tester"
+import { withBus, nextEventFrom } from "./tester"
 import { assert } from "../../src/jdom/utils"
 import ButtonServer from "../../src/servers/buttonserver"
 
@@ -12,30 +12,38 @@ suite("button server", () => {
         const buttonServer = new ButtonServer("button", false)
 
         await withBus([{ server: buttonServer }], async (bus, serviceMap) => {
-            const busTest = new JDBusTestUtil(bus) // TODO needs better name, also boilerplate?
             const buttonService = serviceMap.get(buttonServer) // TODO boilerplate, think about how to eliminate
 
             buttonServer.down()
             assert(
-                (await busTest.nextEventWithin(buttonService, { within: 100 }))
+                (await nextEventFrom(buttonService, { within: 100 }))
                     .code == ButtonEvent.Down
             )
 
             buttonServer.up()
             assert(
-                (await busTest.nextEventWithin(buttonService, { within: 100 }))
+                (await nextEventFrom(buttonService, { within: 100 }))
                     .code == ButtonEvent.Up
             )
+        })
+    })
+
+    test("fires both down and hold events when held", async function () {
+        const buttonServer = new ButtonServer("button", false)
+
+        await withBus([{ server: buttonServer }], async (bus, serviceMap) => {
+            const buttonService = serviceMap.get(buttonServer) // TODO boilerplate, think about how to eliminate
 
             buttonServer.down()
             assert(
-                (await busTest.nextEventWithin(buttonService, { within: 100 }))
+                (await nextEventFrom(buttonService, { within: 100 }))
                     .code == ButtonEvent.Down
             )
             assert(
-                (await busTest.nextEventWithin(buttonService, { after: 500, tolerance: 100 }))
+                (await nextEventFrom(buttonService, { after: 500, tolerance: 100 }))
                     .code == ButtonEvent.Hold
             )  
         })
     })
+
 })

--- a/tests/jdom/button.spec.ts
+++ b/tests/jdom/button.spec.ts
@@ -3,7 +3,7 @@
 
 import { suite, test } from "mocha"
 import { ButtonEvent } from "../../src/jdom/constants"
-import { withBus, nextEventFrom } from "./tester"
+import { withBus, createServices, nextEventFrom } from "./tester"
 import { assert } from "../../src/jdom/utils"
 import ButtonServer from "../../src/servers/buttonserver"
 
@@ -11,18 +11,18 @@ suite("button server", () => {
     test("fires edge events after changing state", async function () {
         const buttonServer = new ButtonServer("button", false)
 
-        await withBus([{ server: buttonServer }], async (bus, serviceMap) => {
-            const buttonService = serviceMap.get(buttonServer) // TODO boilerplate, think about how to eliminate
+        await withBus(async bus => {
+            const {button} = await createServices(bus, {button: buttonServer})
 
             buttonServer.down()
             assert(
-                (await nextEventFrom(buttonService, { within: 100 })).code ==
+                (await nextEventFrom(button, { within: 100 })).code ==
                     ButtonEvent.Down
             )
 
             buttonServer.up()
             assert(
-                (await nextEventFrom(buttonService, { within: 100 })).code ==
+                (await nextEventFrom(button, { within: 100 })).code ==
                     ButtonEvent.Up
             )
         })
@@ -31,17 +31,17 @@ suite("button server", () => {
     test("fires both down and hold events when held", async function () {
         const buttonServer = new ButtonServer("button", false)
 
-        await withBus([{ server: buttonServer }], async (bus, serviceMap) => {
-            const buttonService = serviceMap.get(buttonServer) // TODO boilerplate, think about how to eliminate
+        await withBus(async bus => {
+            const {button} = await createServices(bus, {button: buttonServer})
 
             buttonServer.down()
             assert(
-                (await nextEventFrom(buttonService, { within: 100 })).code ==
+                (await nextEventFrom(button, { within: 100 })).code ==
                     ButtonEvent.Down
             )
             assert(
                 (
-                    await nextEventFrom(buttonService, {
+                    await nextEventFrom(button, {
                         after: 500,
                         tolerance: 100,
                     })
@@ -53,17 +53,17 @@ suite("button server", () => {
     test("repeatedly raise hold events when held", async function () {
         const buttonServer = new ButtonServer("button", false)
 
-        await withBus([{ server: buttonServer }], async (bus, serviceMap) => {
-            const buttonService = serviceMap.get(buttonServer) // TODO boilerplate, think about how to eliminate
+        await withBus(async bus => {
+            const {button} = await createServices(bus, {button: buttonServer})
 
             buttonServer.down()
             assert(
-                (await nextEventFrom(buttonService, { within: 100 })).code ==
+                (await nextEventFrom(button, { within: 100 })).code ==
                     ButtonEvent.Down
             )
             assert(
                 (
-                    await nextEventFrom(buttonService, {
+                    await nextEventFrom(button, {
                         after: 500,
                         tolerance: 100,
                     })
@@ -71,7 +71,7 @@ suite("button server", () => {
             )
             assert(
                 (
-                    await nextEventFrom(buttonService, {
+                    await nextEventFrom(button, {
                         after: 500,
                         tolerance: 100,
                     })
@@ -80,10 +80,10 @@ suite("button server", () => {
 
             buttonServer.up()
             assert(
-                (await nextEventFrom(buttonService, { within: 100 })).code ==
+                (await nextEventFrom(button, { within: 100 })).code ==
                     ButtonEvent.Up
             )
-            await nextEventFrom(buttonService, { within: 1000 }).then(
+            await nextEventFrom(button, { within: 1000 }).then(
                 () => {
                     assert(false, "got event from button after release")
                 },
@@ -95,17 +95,17 @@ suite("button server", () => {
     test("detects repeated holds", async function () {
         const buttonServer = new ButtonServer("button", false)
 
-        await withBus([{ server: buttonServer }], async (bus, serviceMap) => {
-            const buttonService = serviceMap.get(buttonServer) // TODO boilerplate, think about how to eliminate
+        await withBus(async bus => {
+            const {button} = await createServices(bus, {button: buttonServer})
 
             buttonServer.down()
             assert(
-                (await nextEventFrom(buttonService, { within: 100 })).code ==
+                (await nextEventFrom(button, { within: 100 })).code ==
                     ButtonEvent.Down
             )
             assert(
                 (
-                    await nextEventFrom(buttonService, {
+                    await nextEventFrom(button, {
                         after: 500,
                         tolerance: 100,
                     })
@@ -114,18 +114,18 @@ suite("button server", () => {
 
             buttonServer.up()
             assert(
-                (await nextEventFrom(buttonService, { within: 100 })).code ==
+                (await nextEventFrom(button, { within: 100 })).code ==
                     ButtonEvent.Up
             )
 
             buttonServer.down()
             assert(
-                (await nextEventFrom(buttonService, { within: 100 })).code ==
+                (await nextEventFrom(button, { within: 100 })).code ==
                     ButtonEvent.Down
             )
             assert(
                 (
-                    await nextEventFrom(buttonService, {
+                    await nextEventFrom(button, {
                         after: 500,
                         tolerance: 100,
                     })

--- a/tests/jdom/button.spec.ts
+++ b/tests/jdom/button.spec.ts
@@ -26,6 +26,16 @@ suite("button server", () => {
                 (await busTest.nextEventWithin(buttonService, { within: 100 }))
                     .code == ButtonEvent.Up
             )
+
+            buttonServer.down()
+            assert(
+                (await busTest.nextEventWithin(buttonService, { within: 100 }))
+                    .code == ButtonEvent.Down
+            )
+            assert(
+                (await busTest.nextEventWithin(buttonService, { after: 500, tolerance: 100 }))
+                    .code == ButtonEvent.Hold
+            )  
         })
     })
 })

--- a/tests/jdom/button.spec.ts
+++ b/tests/jdom/button.spec.ts
@@ -2,29 +2,30 @@
 // Yes, we're meta-testing!
 
 import { suite, test } from "mocha"
-import { ButtonEvent } from "../../src/jdom/constants";
-import {withBus, JDBusTestUtil} from "./tester";
-import { assert } from "../../src/jdom/utils";
-import ButtonServer from "../../src/servers/buttonserver";
+import { ButtonEvent } from "../../src/jdom/constants"
+import { withBus, JDBusTestUtil } from "./tester"
+import { assert } from "../../src/jdom/utils"
+import ButtonServer from "../../src/servers/buttonserver"
 
-
-suite('button server', () => {
-    test('fires edge events after changing state', async function() {
+suite("button server", () => {
+    test("fires edge events after changing state", async function () {
         const buttonServer = new ButtonServer("button", false)
 
-        await withBus([
-            {server: buttonServer},
-        ], async (bus, serviceMap) => {
-            const busTest = new JDBusTestUtil(bus)  // TODO needs better name, also boilerplate?
-            const buttonService = serviceMap.get(buttonServer)  // TODO boilerplate, think about how to eliminate
+        await withBus([{ server: buttonServer }], async (bus, serviceMap) => {
+            const busTest = new JDBusTestUtil(bus) // TODO needs better name, also boilerplate?
+            const buttonService = serviceMap.get(buttonServer) // TODO boilerplate, think about how to eliminate
 
             buttonServer.down()
-            assert((await busTest.nextEventWithin(buttonService, {within: 100})).code == 
-                ButtonEvent.Down)
+            assert(
+                (await busTest.nextEventWithin(buttonService, { within: 100 }))
+                    .code == ButtonEvent.Down
+            )
 
             buttonServer.up()
-            assert((await busTest.nextEventWithin(buttonService, {within: 100})).code == 
-                ButtonEvent.Up)
+            assert(
+                (await busTest.nextEventWithin(buttonService, { within: 100 }))
+                    .code == ButtonEvent.Up
+            )
         })
     })
-});
+})

--- a/tests/jdom/button.spec.ts
+++ b/tests/jdom/button.spec.ts
@@ -12,8 +12,10 @@ suite("button server", () => {
         const buttonServer = new ButtonServer("button", false)
 
         await withBus(async bus => {
-            const {button} = await createServices(bus, {button: buttonServer})
-
+            const { button } = await createServices(bus, {
+                button: buttonServer,
+            })
+            
             buttonServer.down()
             assert(
                 (await nextEventFrom(button, { within: 100 })).code ==
@@ -32,7 +34,9 @@ suite("button server", () => {
         const buttonServer = new ButtonServer("button", false)
 
         await withBus(async bus => {
-            const {button} = await createServices(bus, {button: buttonServer})
+            const { button } = await createServices(bus, {
+                button: buttonServer,
+            })
 
             buttonServer.down()
             assert(
@@ -54,7 +58,9 @@ suite("button server", () => {
         const buttonServer = new ButtonServer("button", false)
 
         await withBus(async bus => {
-            const {button} = await createServices(bus, {button: buttonServer})
+            const { button } = await createServices(bus, {
+                button: buttonServer,
+            })
 
             buttonServer.down()
             assert(
@@ -96,7 +102,9 @@ suite("button server", () => {
         const buttonServer = new ButtonServer("button", false)
 
         await withBus(async bus => {
-            const {button} = await createServices(bus, {button: buttonServer})
+            const { button } = await createServices(bus, {
+                button: buttonServer,
+            })
 
             buttonServer.down()
             assert(

--- a/tests/jdom/button.spec.ts
+++ b/tests/jdom/button.spec.ts
@@ -15,7 +15,7 @@ suite("button server", () => {
             const { button } = await createServices(bus, {
                 button: buttonServer,
             })
-            
+
             buttonServer.down()
             assert(
                 (await nextEventFrom(button, { within: 100 })).code ==

--- a/tests/jdom/button.spec.ts
+++ b/tests/jdom/button.spec.ts
@@ -1,0 +1,30 @@
+// Test the ButtonServer, intended as a test for the unit test framework.
+// Yes, we're meta-testing!
+
+import { suite, test } from "mocha"
+import { ButtonEvent } from "../../src/jdom/constants";
+import {withBus, JDBusTestUtil} from "./tester";
+import { assert } from "../../src/jdom/utils";
+import ButtonServer from "../../src/servers/buttonserver";
+
+
+suite('button server', () => {
+    test('fires edge events after changing state', async function() {
+        const buttonServer = new ButtonServer("button", false)
+
+        await withBus([
+            {server: buttonServer},
+        ], async (bus, serviceMap) => {
+            const busTest = new JDBusTestUtil(bus)  // TODO needs better name, also boilerplate?
+            const buttonService = serviceMap.get(buttonServer)  // TODO boilerplate, think about how to eliminate
+
+            buttonServer.down()
+            assert((await busTest.nextEventWithin(buttonService, {within: 100})).code == 
+                ButtonEvent.Down)
+
+            buttonServer.up()
+            assert((await busTest.nextEventWithin(buttonService, {within: 100})).code == 
+                ButtonEvent.Up)
+        })
+    })
+});

--- a/tests/jdom/button.spec.ts
+++ b/tests/jdom/button.spec.ts
@@ -16,14 +16,14 @@ suite("button server", () => {
 
             buttonServer.down()
             assert(
-                (await nextEventFrom(buttonService, { within: 100 }))
-                    .code == ButtonEvent.Down
+                (await nextEventFrom(buttonService, { within: 100 })).code ==
+                    ButtonEvent.Down
             )
 
             buttonServer.up()
             assert(
-                (await nextEventFrom(buttonService, { within: 100 }))
-                    .code == ButtonEvent.Up
+                (await nextEventFrom(buttonService, { within: 100 })).code ==
+                    ButtonEvent.Up
             )
         })
     })
@@ -36,14 +36,59 @@ suite("button server", () => {
 
             buttonServer.down()
             assert(
-                (await nextEventFrom(buttonService, { within: 100 }))
-                    .code == ButtonEvent.Down
+                (await nextEventFrom(buttonService, { within: 100 })).code ==
+                    ButtonEvent.Down
             )
             assert(
-                (await nextEventFrom(buttonService, { after: 500, tolerance: 100 }))
-                    .code == ButtonEvent.Hold
-            )  
+                (
+                    await nextEventFrom(buttonService, {
+                        after: 500,
+                        tolerance: 100,
+                    })
+                ).code == ButtonEvent.Hold
+            )
         })
     })
 
+    test("detects repeated holds", async function () {
+        const buttonServer = new ButtonServer("button", false)
+
+        await withBus([{ server: buttonServer }], async (bus, serviceMap) => {
+            const buttonService = serviceMap.get(buttonServer) // TODO boilerplate, think about how to eliminate
+
+            buttonServer.down()
+            assert(
+                (await nextEventFrom(buttonService, { within: 100 })).code ==
+                    ButtonEvent.Down
+            )
+            assert(
+                (
+                    await nextEventFrom(buttonService, {
+                        after: 500,
+                        tolerance: 100,
+                    })
+                ).code == ButtonEvent.Hold
+            )
+
+            buttonServer.up()
+            assert(
+                (await nextEventFrom(buttonService, { within: 100 })).code ==
+                    ButtonEvent.Up
+            )
+
+            buttonServer.down()
+            assert(
+                (await nextEventFrom(buttonService, { within: 100 })).code ==
+                    ButtonEvent.Down
+            )
+            assert(
+                (
+                    await nextEventFrom(buttonService, {
+                        after: 500,
+                        tolerance: 100,
+                    })
+                ).code == ButtonEvent.Hold
+            )
+        })
+    })
 })

--- a/tests/jdom/button.spec.ts
+++ b/tests/jdom/button.spec.ts
@@ -9,43 +9,39 @@ import ButtonServer from "../../src/servers/buttonserver"
 
 suite("button server", () => {
     test("fires edge events after changing state", async function () {
-        const buttonServer = new ButtonServer("button", false)
-
         await withBus(async bus => {
             const { button } = await createServices(bus, {
-                button: buttonServer,
+                button: new ButtonServer("button", false),
             })
 
-            buttonServer.down()
+            button.server.down()
             assert(
-                (await nextEventFrom(button, { within: 100 })).code ==
+                (await nextEventFrom(button.service, { within: 100 })).code ==
                     ButtonEvent.Down
             )
 
-            buttonServer.up()
+            button.server.up()
             assert(
-                (await nextEventFrom(button, { within: 100 })).code ==
+                (await nextEventFrom(button.service, { within: 100 })).code ==
                     ButtonEvent.Up
             )
         })
     })
 
     test("fires both down and hold events when held", async function () {
-        const buttonServer = new ButtonServer("button", false)
-
         await withBus(async bus => {
             const { button } = await createServices(bus, {
-                button: buttonServer,
+                button: new ButtonServer("button", false),
             })
 
-            buttonServer.down()
+            button.server.down()
             assert(
-                (await nextEventFrom(button, { within: 100 })).code ==
+                (await nextEventFrom(button.service, { within: 100 })).code ==
                     ButtonEvent.Down
             )
             assert(
                 (
-                    await nextEventFrom(button, {
+                    await nextEventFrom(button.service, {
                         after: 500,
                         tolerance: 100,
                     })
@@ -55,21 +51,19 @@ suite("button server", () => {
     })
 
     test("repeatedly raise hold events when held", async function () {
-        const buttonServer = new ButtonServer("button", false)
-
         await withBus(async bus => {
             const { button } = await createServices(bus, {
-                button: buttonServer,
+                button: new ButtonServer("button", false),
             })
 
-            buttonServer.down()
+            button.server.down()
             assert(
-                (await nextEventFrom(button, { within: 100 })).code ==
+                (await nextEventFrom(button.service, { within: 100 })).code ==
                     ButtonEvent.Down
             )
             assert(
                 (
-                    await nextEventFrom(button, {
+                    await nextEventFrom(button.service, {
                         after: 500,
                         tolerance: 100,
                     })
@@ -77,19 +71,19 @@ suite("button server", () => {
             )
             assert(
                 (
-                    await nextEventFrom(button, {
+                    await nextEventFrom(button.service, {
                         after: 500,
                         tolerance: 100,
                     })
                 ).code == ButtonEvent.Hold
             )
 
-            buttonServer.up()
+            button.server.up()
             assert(
-                (await nextEventFrom(button, { within: 100 })).code ==
+                (await nextEventFrom(button.service, { within: 100 })).code ==
                     ButtonEvent.Up
             )
-            await nextEventFrom(button, { within: 1000 }).then(
+            await nextEventFrom(button.service, { within: 1000 }).then(
                 () => {
                     assert(false, "got event from button after release")
                 },
@@ -99,41 +93,39 @@ suite("button server", () => {
     }).timeout(3000) // TODO remove when we can fast-forward tests
 
     test("detects repeated holds", async function () {
-        const buttonServer = new ButtonServer("button", false)
-
         await withBus(async bus => {
             const { button } = await createServices(bus, {
-                button: buttonServer,
+                button: new ButtonServer("button", false),
             })
 
-            buttonServer.down()
+            button.server.down()
             assert(
-                (await nextEventFrom(button, { within: 100 })).code ==
+                (await nextEventFrom(button.service, { within: 100 })).code ==
                     ButtonEvent.Down
             )
             assert(
                 (
-                    await nextEventFrom(button, {
+                    await nextEventFrom(button.service, {
                         after: 500,
                         tolerance: 100,
                     })
                 ).code == ButtonEvent.Hold
             )
 
-            buttonServer.up()
+            button.server.up()
             assert(
-                (await nextEventFrom(button, { within: 100 })).code ==
+                (await nextEventFrom(button.service, { within: 100 })).code ==
                     ButtonEvent.Up
             )
 
-            buttonServer.down()
+            button.server.down()
             assert(
-                (await nextEventFrom(button, { within: 100 })).code ==
+                (await nextEventFrom(button.service, { within: 100 })).code ==
                     ButtonEvent.Down
             )
             assert(
                 (
-                    await nextEventFrom(button, {
+                    await nextEventFrom(button.service, {
                         after: 500,
                         tolerance: 100,
                     })

--- a/tests/jdom/tester.ts
+++ b/tests/jdom/tester.ts
@@ -1,0 +1,193 @@
+import { JDBus } from "../../src/jdom/bus"
+import JDServiceProvider from "../../src/jdom/serviceprovider"
+import { EVENT, DEVICE_ANNOUNCE } from "../../src/jdom/constants";
+import { mkBus } from "../testutils";
+
+import { JDEvent } from "../../src/jdom/event";
+import { JDDevice } from "../../src/jdom/device";
+import RoleManager from "../../src/servers/rolemanager"
+import JDServiceServer from "../../src/jdom/serviceserver";
+import { assert } from "../../src/jdom/utils";
+import { JDService } from "../../src/jdom/service";
+
+
+// how the heck is this not a native operation
+function setEquals<T>(set1: Set<T>, set2: Set<T>): boolean {
+    if (set1.size != set2.size) {
+        return false
+    }
+    set1.forEach(value => {
+        if (!set2.has(value)) {
+            return false
+        }
+    })
+    return true
+}
+
+
+interface ServerDevice {
+    server: JDServiceServer,
+    roleName?: string,
+}
+
+
+// Creates a bus with the specified servers, bound to the specified roles.
+// Returns once all devices are registered, and adapters are ready.
+export async function withBus(devices: ServerDevice[], 
+    test: (bus: JDBus, serviceMap: Map<JDServiceServer, JDService>) => Promise<void>) {
+    const bus = mkBus()
+
+    // For server devices: add the service provider on the bus and return the device
+    const serverDevices = devices.map(device => {
+        const busDevice = bus.addServiceProvider(new JDServiceProvider(
+            [(<ServerDevice>device).server] 
+        ))
+        return {
+            server: (<ServerDevice>device).server,
+            busDevice: busDevice,
+            roleName: (<ServerDevice>device).roleName,
+        }
+    })
+
+    bus.start()
+
+    // Wait for created devices to be announced, so services become available
+    const serverDeviceIds = serverDevices.map(elt => {
+        return elt.busDevice.deviceId
+    })
+    await new Promise(resolve => {
+        const devicesIdSet = new Set(serverDeviceIds)
+        const announcedIdSet = new Set()
+        const onHandler = (device: JDDevice) => {
+            if (devicesIdSet.has(device.deviceId)) {
+                announcedIdSet.add(device.deviceId)
+            }
+            if (setEquals(devicesIdSet, announcedIdSet)) {
+                bus.off(DEVICE_ANNOUNCE, onHandler)
+                resolve(undefined)
+            }
+        }
+        bus.on(DEVICE_ANNOUNCE, onHandler)
+    })
+
+    // Bind services to roles
+    // Start by geting server service -> roleName mappings
+    const serverServiceRoles = serverDevices.map(elt => {
+        const services = elt.busDevice.services({serviceClass: elt.server.serviceClass})
+        assert(services.length > 0, 
+            `created device ${elt.busDevice.friendlyName} has no service of ${elt.server.specification.name}`)
+        assert(services.length == 1, 
+            `created device ${elt.busDevice.friendlyName} has multiple service of ${elt.server.specification.name}`)
+        return {
+            service: services[0],
+            roleName: elt.roleName
+        }
+    })
+
+    const roleBindings = serverServiceRoles.filter(elt => {
+        return !!elt.roleName  // filter for where role name is available
+    }).map(elt => {
+        return {
+            role: elt.roleName, 
+            serviceClass: elt.service.specification.classIdentifier,
+            service: elt.service,
+        }
+    })
+
+    const roleManager = new RoleManager(bus)
+    roleManager.setRoles(roleBindings)
+
+    // Return created services as a map from the source server
+    // Trace devices are ignored here, since handles aren't (currently?) useful
+    const serviceMap = new Map(
+        serverDevices.map(elt => {
+            return [elt.server, elt.busDevice.services({serviceClass: elt.server.serviceClass})[0]]
+        })
+    )
+
+    // Actually run the test here
+    await test(bus, serviceMap)
+
+    bus.stop()
+}
+
+
+interface EventWithinOptions {
+    after?: number  // event must happen at least this many ms after the current time (by default, 0)
+    within?: number  // event must happen within this many ms after the current time (by default, infinite)
+    tolerance?: number  // when after is set, sets the allowable range for the event to be tolerance on either side of after
+                        // is an error if within is set, or after is not set
+}
+
+
+export class JDBusTestUtil {
+    // TODO should this also encapsulate the serviceMap?
+    constructor(protected readonly bus: JDBus) {
+    }
+
+    // Waits for the next event from a service, and returns the event.
+    // The event must not have triggered already.
+    // TODO should events in the past be supported?
+    public nextEventFrom(service: JDService): Promise<JDEvent> {
+        return new Promise(resolve => service.once(EVENT, (event: JDEvent) => {
+            resolve(event)
+        }))
+    }
+
+    // Waits for the next event from a service, within some time.
+    // If no event is triggered within the time, the promise is rejected at within time.
+    // TODO should events in the past be supported (negative after / within)?
+    public nextEventWithin(service: JDService, eventWithin: EventWithinOptions = {}): Promise<JDEvent> {
+        let after: number, within: number
+        if (eventWithin.tolerance !== undefined) {
+            assert(eventWithin.after !== undefined, "tolerance must be used with after")
+            assert(eventWithin.within == undefined, "tolerance may not be used with within")
+            after = eventWithin.after - eventWithin.tolerance
+            within = eventWithin.after + eventWithin.tolerance
+        } else {
+            after = (eventWithin.after === undefined) ? 0 : eventWithin.after
+            within = (eventWithin.within === undefined) ? Number.POSITIVE_INFINITY : eventWithin.within
+        }
+
+        const startTimestamp = this.bus.timestamp
+        const nextEventPromise: Promise<JDEvent> = new Promise(resolve => 
+            service.once(EVENT, (event: JDEvent) => { resolve(event) }
+        ))
+        
+        let firstPromise: Promise<JDEvent | null>
+        if (within != Number.POSITIVE_INFINITY) {  // finite within, set a timeout
+            const timeoutPromise: Promise<null> = new Promise(resolve => 
+                this.bus.scheduler.setTimeout(() => { resolve(null) }, within))
+            firstPromise = Promise.race([
+                nextEventPromise,
+                timeoutPromise
+            ])
+        } else {  // infinite within, don't set a separate timeout
+            firstPromise = nextEventPromise
+        }
+
+        return new Promise((resolve, reject) => {
+            firstPromise.then(value => {
+                if (value != null) {
+                    const elapsedTime = this.bus.timestamp - startTimestamp
+                    if (elapsedTime < after) {
+                        if (eventWithin.tolerance !== undefined) {
+                            reject(new Error(`nextEventWithin got event at ${elapsedTime} ms, before after=${after} ms (${eventWithin.after}±${eventWithin.tolerance} ms)`))
+                        } else {
+                            reject(new Error(`nextEventWithin got event at ${elapsedTime} ms, before after=${after} ms`))
+                        }
+                    } else {
+                        resolve(value)
+                    }
+                } else {
+                    if (eventWithin.tolerance !== undefined) {
+                        reject(new Error(`nextEventWithin timed out at within=${within} ms (${eventWithin.after}±${eventWithin.tolerance} ms)`))
+                    } else {
+                        reject(new Error(`nextEventWithin timed out at within=${within} ms`))
+                    }
+                }
+            })
+    
+        })
+    }
+}

--- a/tests/jdom/tester.ts
+++ b/tests/jdom/tester.ts
@@ -50,9 +50,9 @@ export async function withBus(devices: ServerDevice[],
     bus.start()
 
     // Wait for created devices to be announced, so services become available
-    const serverDeviceIds = serverDevices.map(elt => {
-        return elt.busDevice.deviceId
-    })
+    const serverDeviceIds = serverDevices.map(elt =>
+        elt.busDevice.deviceId
+    )
     await new Promise(resolve => {
         const devicesIdSet = new Set(serverDeviceIds)
         const announcedIdSet = new Set()
@@ -82,9 +82,9 @@ export async function withBus(devices: ServerDevice[],
         }
     })
 
-    const roleBindings = serverServiceRoles.filter(elt => {
-        return !!elt.roleName  // filter for where role name is available
-    }).map(elt => {
+    const roleBindings = serverServiceRoles.filter(elt =>
+        !!elt.roleName  // filter for where role name is available
+    ).map(elt => {
         return {
             role: elt.roleName, 
             serviceClass: elt.service.specification.classIdentifier,
@@ -98,9 +98,9 @@ export async function withBus(devices: ServerDevice[],
     // Return created services as a map from the source server
     // Trace devices are ignored here, since handles aren't (currently?) useful
     const serviceMap = new Map(
-        serverDevices.map(elt => {
-            return [elt.server, elt.busDevice.services({serviceClass: elt.server.serviceClass})[0]]
-        })
+        serverDevices.map(elt =>
+            [elt.server, elt.busDevice.services({serviceClass: elt.server.serviceClass})[0]]
+        )
     )
 
     // Actually run the test here

--- a/tests/jdom/tester.ts
+++ b/tests/jdom/tester.ts
@@ -1,15 +1,14 @@
 import { JDBus } from "../../src/jdom/bus"
 import JDServiceProvider from "../../src/jdom/serviceprovider"
-import { EVENT, DEVICE_ANNOUNCE } from "../../src/jdom/constants";
-import { mkBus } from "../testutils";
+import { EVENT, DEVICE_ANNOUNCE } from "../../src/jdom/constants"
+import { mkBus } from "../testutils"
 
-import { JDEvent } from "../../src/jdom/event";
-import { JDDevice } from "../../src/jdom/device";
+import { JDEvent } from "../../src/jdom/event"
+import { JDDevice } from "../../src/jdom/device"
 import RoleManager from "../../src/servers/rolemanager"
-import JDServiceServer from "../../src/jdom/serviceserver";
-import { assert } from "../../src/jdom/utils";
-import { JDService } from "../../src/jdom/service";
-
+import JDServiceServer from "../../src/jdom/serviceserver"
+import { assert } from "../../src/jdom/utils"
+import { JDService } from "../../src/jdom/service"
 
 // Set equals is not a built-in operation.
 function setEquals<T>(set1: Set<T>, set2: Set<T>): boolean {
@@ -24,22 +23,27 @@ function setEquals<T>(set1: Set<T>, set2: Set<T>): boolean {
     return true
 }
 
-
 interface ServerDevice {
-    server: JDServiceServer,
-    roleName?: string,
+    server: JDServiceServer
+    roleName?: string
 }
-
 
 // Creates a bus with the specified servers (optionally bound to the specified roles),
 // then runs the test function.
-export async function withBus(devices: ServerDevice[], 
-    test: (bus: JDBus, serviceMap: Map<JDServiceServer, JDService>) => Promise<void>) {
+export async function withBus(
+    devices: ServerDevice[],
+    test: (
+        bus: JDBus,
+        serviceMap: Map<JDServiceServer, JDService>
+    ) => Promise<void>
+) {
     const bus = mkBus()
 
     // For server devices: add the service provider on the bus and return the device
     const serverDevices = devices.map(device => {
-        const busDevice = bus.addServiceProvider(new JDServiceProvider([device.server]))
+        const busDevice = bus.addServiceProvider(
+            new JDServiceProvider([device.server])
+        )
         return {
             server: device.server,
             busDevice: busDevice,
@@ -50,9 +54,7 @@ export async function withBus(devices: ServerDevice[],
     bus.start()
 
     // Wait for created devices to be announced, so services become available
-    const serverDeviceIds = serverDevices.map(elt =>
-        elt.busDevice.deviceId
-    )
+    const serverDeviceIds = serverDevices.map(elt => elt.busDevice.deviceId)
     await new Promise(resolve => {
         const devicesIdSet = new Set(serverDeviceIds)
         const announcedIdSet = new Set()
@@ -71,36 +73,46 @@ export async function withBus(devices: ServerDevice[],
     // Bind services to roles
     // Start by geting server service -> roleName mappings
     const serverServiceRoles = serverDevices.map(elt => {
-        const services = elt.busDevice.services({serviceClass: elt.server.serviceClass})
-        assert(services.length > 0, 
-            `created device ${elt.busDevice.friendlyName} has no service of ${elt.server.specification.name}`)
-        assert(services.length == 1, 
-            `created device ${elt.busDevice.friendlyName} has multiple service of ${elt.server.specification.name}`)
+        const services = elt.busDevice.services({
+            serviceClass: elt.server.serviceClass,
+        })
+        assert(
+            services.length > 0,
+            `created device ${elt.busDevice.friendlyName} has no service of ${elt.server.specification.name}`
+        )
+        assert(
+            services.length == 1,
+            `created device ${elt.busDevice.friendlyName} has multiple service of ${elt.server.specification.name}`
+        )
         return {
             service: services[0],
-            roleName: elt.roleName
+            roleName: elt.roleName,
         }
     })
 
-    const roleBindings = serverServiceRoles.filter(elt =>
-        !!elt.roleName  // filter for where role name is available
-    ).map(elt => {
-        return {
-            role: elt.roleName, 
-            serviceClass: elt.service.specification.classIdentifier,
-            service: elt.service,
-        }
-    })
+    const roleBindings = serverServiceRoles
+        .filter(
+            elt => !!elt.roleName // filter for where role name is available
+        )
+        .map(elt => {
+            return {
+                role: elt.roleName,
+                serviceClass: elt.service.specification.classIdentifier,
+                service: elt.service,
+            }
+        })
 
     const roleManager = new RoleManager(bus)
     roleManager.setRoles(roleBindings)
 
     // Return created services as a map from the source server
-    // Trace devices are ignored here, since handles aren't (currently?) useful
     const serviceMap = new Map(
-        serverDevices.map(elt =>
-            [elt.server, elt.busDevice.services({serviceClass: elt.server.serviceClass})[0]]
-        )
+        serverDevices.map(elt => [
+            elt.server,
+            elt.busDevice.services({
+                serviceClass: elt.server.serviceClass,
+            })[0],
+        ])
     )
 
     // Actually run the test here
@@ -109,58 +121,73 @@ export async function withBus(devices: ServerDevice[],
     bus.stop()
 }
 
-
 interface EventWithinOptions {
-    after?: number  // event must happen at least this many ms after the current time (by default, 0)
-    within?: number  // event must happen within this many ms after the current time (by default, infinite)
-    tolerance?: number  // when after is set, sets the allowable range for the event to be tolerance on either side of after
-                        // is an error if within is set, or after is not set
+    after?: number // event must happen at least this many ms after the current time (by default, 0)
+    within?: number // event must happen within this many ms after the current time (by default, infinite)
+    tolerance?: number // when after is set, sets the allowable range for the event to be tolerance on either side of after
+    // is an error if within is set, or after is not set
 }
-
 
 export class JDBusTestUtil {
     // TODO should this also encapsulate the serviceMap?
-    constructor(protected readonly bus: JDBus) {
-    }
+    constructor(protected readonly bus: JDBus) {}
 
     // Waits for the next event from a service, and returns the event.
     // The event must not have triggered already.
     // TODO should events in the past be supported?
     public nextEventFrom(service: JDService): Promise<JDEvent> {
-        return new Promise(resolve => service.once(EVENT, (event: JDEvent) => {
-            resolve(event)
-        }))
+        return new Promise(resolve =>
+            service.once(EVENT, (event: JDEvent) => {
+                resolve(event)
+            })
+        )
     }
 
     // Waits for the next event from a service, within some time.
     // If no event is triggered within the time, the promise is rejected at within time.
     // TODO should events in the past be supported (negative after / within)?
-    public nextEventWithin(service: JDService, eventWithin: EventWithinOptions = {}): Promise<JDEvent> {
+    public nextEventWithin(
+        service: JDService,
+        eventWithin: EventWithinOptions = {}
+    ): Promise<JDEvent> {
         let after: number, within: number
         if (eventWithin.tolerance !== undefined) {
-            assert(eventWithin.after !== undefined, "tolerance must be used with after")
-            assert(eventWithin.within == undefined, "tolerance may not be used with within")
+            assert(
+                eventWithin.after !== undefined,
+                "tolerance must be used with after"
+            )
+            assert(
+                eventWithin.within == undefined,
+                "tolerance may not be used with within"
+            )
             after = eventWithin.after - eventWithin.tolerance
             within = eventWithin.after + eventWithin.tolerance
         } else {
-            after = (eventWithin.after === undefined) ? 0 : eventWithin.after
-            within = (eventWithin.within === undefined) ? Number.POSITIVE_INFINITY : eventWithin.within
+            after = eventWithin.after === undefined ? 0 : eventWithin.after
+            within =
+                eventWithin.within === undefined
+                    ? Number.POSITIVE_INFINITY
+                    : eventWithin.within
         }
 
         const startTimestamp = this.bus.timestamp
-        const nextEventPromise: Promise<JDEvent> = new Promise(resolve => 
-            service.once(EVENT, (event: JDEvent) => { resolve(event) }
-        ))
-        
+        const nextEventPromise: Promise<JDEvent> = new Promise(resolve =>
+            service.once(EVENT, (event: JDEvent) => {
+                resolve(event)
+            })
+        )
+
         let firstPromise: Promise<JDEvent | null>
-        if (within != Number.POSITIVE_INFINITY) {  // finite within, set a timeout
-            const timeoutPromise: Promise<null> = new Promise(resolve => 
-                this.bus.scheduler.setTimeout(() => { resolve(null) }, within))
-            firstPromise = Promise.race([
-                nextEventPromise,
-                timeoutPromise
-            ])
-        } else {  // infinite within, don't set a separate timeout
+        if (within != Number.POSITIVE_INFINITY) {
+            // finite within, set a timeout
+            const timeoutPromise: Promise<null> = new Promise(resolve =>
+                this.bus.scheduler.setTimeout(() => {
+                    resolve(null)
+                }, within)
+            )
+            firstPromise = Promise.race([nextEventPromise, timeoutPromise])
+        } else {
+            // infinite within, don't set a separate timeout
             firstPromise = nextEventPromise
         }
 
@@ -170,22 +197,37 @@ export class JDBusTestUtil {
                     const elapsedTime = this.bus.timestamp - startTimestamp
                     if (elapsedTime < after) {
                         if (eventWithin.tolerance !== undefined) {
-                            reject(new Error(`nextEventWithin got event at ${elapsedTime} ms, before after=${after} ms (${eventWithin.after}±${eventWithin.tolerance} ms)`))
+                            reject(
+                                new Error(
+                                    `nextEventWithin got event at ${elapsedTime} ms, before after=${after} ms (${eventWithin.after}±${eventWithin.tolerance} ms)`
+                                )
+                            )
                         } else {
-                            reject(new Error(`nextEventWithin got event at ${elapsedTime} ms, before after=${after} ms`))
+                            reject(
+                                new Error(
+                                    `nextEventWithin got event at ${elapsedTime} ms, before after=${after} ms`
+                                )
+                            )
                         }
                     } else {
                         resolve(value)
                     }
                 } else {
                     if (eventWithin.tolerance !== undefined) {
-                        reject(new Error(`nextEventWithin timed out at within=${within} ms (${eventWithin.after}±${eventWithin.tolerance} ms)`))
+                        reject(
+                            new Error(
+                                `nextEventWithin timed out at within=${within} ms (${eventWithin.after}±${eventWithin.tolerance} ms)`
+                            )
+                        )
                     } else {
-                        reject(new Error(`nextEventWithin timed out at within=${within} ms`))
+                        reject(
+                            new Error(
+                                `nextEventWithin timed out at within=${within} ms`
+                            )
+                        )
                     }
                 }
             })
-    
         })
     }
 }

--- a/tests/jdom/tester.ts
+++ b/tests/jdom/tester.ts
@@ -11,7 +11,7 @@ import { assert } from "../../src/jdom/utils";
 import { JDService } from "../../src/jdom/service";
 
 
-// how the heck is this not a native operation
+// Set equals is not a built-in operation.
 function setEquals<T>(set1: Set<T>, set2: Set<T>): boolean {
     if (set1.size != set2.size) {
         return false
@@ -39,13 +39,11 @@ export async function withBus(devices: ServerDevice[],
 
     // For server devices: add the service provider on the bus and return the device
     const serverDevices = devices.map(device => {
-        const busDevice = bus.addServiceProvider(new JDServiceProvider(
-            [(<ServerDevice>device).server] 
-        ))
+        const busDevice = bus.addServiceProvider(new JDServiceProvider([device.server]))
         return {
-            server: (<ServerDevice>device).server,
+            server: device.server,
             busDevice: busDevice,
-            roleName: (<ServerDevice>device).roleName,
+            roleName: device.roleName,
         }
     })
 

--- a/tests/jdom/tester.ts
+++ b/tests/jdom/tester.ts
@@ -35,7 +35,16 @@ export async function withBus(test: (bus: JDBus) => Promise<void>) {
     bus.stop()
 }
 
-// TODO NAMING
+// Creates devices around the given servers, specified as mapping of names to objects.
+// These devices are attached to the bus, and waited on for announcement so services are ready.
+// Returns the services, as an object mapping the input names to the corresponding services.
+//
+// For example,
+// const { button } = await createServices(bus, {
+//   button: new ButtonServer(),
+// })
+//
+// button is a JDServiceServer with service type SRV_BUTTON
 export async function createServices<T extends Record<string, JDServiceServer>>(
     bus: JDBus,
     servers: T

--- a/tests/jdom/tester.ts
+++ b/tests/jdom/tester.ts
@@ -31,8 +31,8 @@ interface ServerDevice {
 }
 
 
-// Creates a bus with the specified servers, bound to the specified roles.
-// Returns once all devices are registered, and adapters are ready.
+// Creates a bus with the specified servers (optionally bound to the specified roles),
+// then runs the test function.
 export async function withBus(devices: ServerDevice[], 
     test: (bus: JDBus, serviceMap: Map<JDServiceServer, JDService>) => Promise<void>) {
     const bus = mkBus()

--- a/tests/jdom/tester.ts
+++ b/tests/jdom/tester.ts
@@ -39,7 +39,6 @@ export async function withBus(test: (bus: JDBus) => Promise<void>) {
 // the created device, and the service on the device corresponding to the server.
 export interface CreatedServerService<ServiceType extends JDServiceServer> {
     server: ServiceType
-    device: JDDevice
     service: JDService
 }
 
@@ -105,7 +104,6 @@ export async function createServices<T extends Record<string, JDServiceServer>>(
                 name,
                 {
                     server: server,
-                    device: device,
                     service: services[0],
                 },
             ]

--- a/tests/jdom/tester.ts
+++ b/tests/jdom/tester.ts
@@ -121,7 +121,7 @@ export async function withBus(
     bus.stop()
 }
 
-interface EventWithinOptions {
+export interface EventWithinOptions {
     after?: number // event must happen at least this many ms after the current time (by default, 0)
     within?: number // event must happen within this many ms after the current time (by default, infinite)
     tolerance?: number // when after is set, sets the allowable range for the event to be tolerance on either side of after


### PR DESCRIPTION
This provides a utility function to create a bus with devices (from servers) and waits for devices to come up before starting the test proper. Also includes test utility functions with some notion of time and time tolerance. Split from #219 . Not a comprehensive test API, but I think that more features should be example-driven.

Includes a basic unit test case (ButtonServer) to test the test utility. Binding roles is supported by the test utility but not tested, since adapters are out of scope here.

TODO in a follow-up PR:
- [ ] Integrate a proper assertion library, like Chai