### PR TITLE
Clone packets in trace

### DIFF
--- a/src/jdom/device.ts
+++ b/src/jdom/device.ts
@@ -865,7 +865,7 @@ export class JDDevice extends JDNode {
         let resends = 0
         this._ackAwaiting = []
         const cleanUp = this.subscribe(PACKET_REPORT, (rep: Packet) => {
-            if (rep.serviceIndex != JD_SERVICE_INDEX_CRC_ACK) return
+            if (!rep.isCRCAck) return
             let numdone = 0
             for (const aa of this._ackAwaiting) {
                 if (aa.pkt && aa.pkt.crc == rep.serviceCommand) {

--- a/src/jdom/trace/trace.ts
+++ b/src/jdom/trace/trace.ts
@@ -87,7 +87,14 @@ export class Trace {
      * @param maxLength If positive, prunes older packets when the length reaches maxLength
      */
     addPacket(packet: Packet) {
-        this.packets.push(packet)
+        // packets are mutable (eg., timestamp is updated on each send), so we take a copy
+        const copy = packet.clone()
+        copy.sender = packet.sender
+        copy.device = packet.device
+        // TODO need to copy 'meta' as well?
+        this.packets.push(copy)
+
+        // limit trace size
         if (
             this.maxLength > 0 &&
             this.packets.length > this.maxLength * TRACE_OVERSHOOT


### PR DESCRIPTION
@pelikhan any idea if we should clone the _meta field as well ?

without this, the packets that are re-sent with acks all get the timestamp of the last send